### PR TITLE
Simplifying logic in resize_text

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -33,23 +33,12 @@ function resize_text(
 	min_size: number,
 	max_size: number
 ): void {
-	let i: number = min_size
-	let overflow: boolean = false
 	let size: number = min_size
 	element.style.fontSize = `${size}px`
-
-	while (!overflow && i < max_size) {
-		overflow = is_overflow(parent)
-
-		if (!overflow) {
-			// If not overflowing, increase the font size
-			element.style.fontSize = `${i}px`
-			i++
-		}
+	while (!is_overflow(parent) && size < max_size) {
+		element.style.fontSize = `${size}px`
+		size++;
 	}
-	size = i - 2
-	// console.log('overflow', i, size, element)
-	element.style.fontSize = `${size}px`
 }
 
 export const parent_style = `display: inline-block;

--- a/index.ts
+++ b/index.ts
@@ -36,8 +36,8 @@ function resize_text(
 	let size: number = min_size
 	element.style.fontSize = `${size}px`
 	while (!is_overflow(parent) && size < max_size) {
+		size++
 		element.style.fontSize = `${size}px`
-		size++;
 	}
 }
 


### PR DESCRIPTION
There was a bit of redundancy in the code:

- variables `i` and `size` are nearly identical
- variable `overflow` isn't necessary: it starts at false, `while` executes at least once, it assigns function result to a value then check for falsiness – instead could check function result directly in `while`
 
I am unsure why `size = i - 2` was needed; if `i` fits then why decrements by 2 pixels?

Great library, could def use it in our team